### PR TITLE
Issue #3 (Enhancement) - update error message only when custom messag…

### DIFF
--- a/frontend/src/MetadataForm.svelte
+++ b/frontend/src/MetadataForm.svelte
@@ -113,7 +113,13 @@
                         .concat(pathArr)
                     defObject = traversePath(completeErrArr)
                 }
-                error.message = defObject["additionalProperties"].default
+
+                if (
+                    defObject["additionalProperties"] != undefined &&
+                    defObject["additionalProperties"].default != undefined
+                ) {
+                    error.message = defObject["additionalProperties"].default
+                }
             }
             return error
         })

--- a/frontend/src/MetadataForm.svelte
+++ b/frontend/src/MetadataForm.svelte
@@ -116,9 +116,9 @@
 
                 if (
                     defObject["additionalProperties"] != undefined &&
-                    defObject["additionalProperties"].default != undefined
+                    defObject["additionalProperties"]["default"] != undefined
                 ) {
-                    error.message = defObject["additionalProperties"].default
+                    error.message = defObject["additionalProperties"]["default"]
                 }
             }
             return error


### PR DESCRIPTION
This fix allows for the pattern-based validation error messages to be replaced for properties that have easy-to-follow custom error messages defined in their schema-definition. For those that don't, error message created by the validator instance will be shown.